### PR TITLE
Fix: Compatibility with SciPy 1.13+ and scikit-bio 0.7.0

### DIFF
--- a/scibd/scibd.py
+++ b/scibd/scibd.py
@@ -89,7 +89,17 @@ def CalJac(A,B=None):##scipy mat
     b_sum = B.sum(axis=1).A1
     xx,yy = np.meshgrid(a_sum, b_sum)
     union = ((xx+yy).T - intersect)
-    jac_distance = (1-intersect/union).A
+
+    # Fix for SciPy 1.13+ compatibility: convert to dense before subtraction
+    # Original: jac_distance = (1-intersect/union).A  # Fails in SciPy 1.13+
+    # Fixed: Convert sparse matrix to array first, then perform subtraction
+    jac_distance = 1 - (intersect/union).toarray()
+
+    # Fix for scikit-bio 0.7.0: ensure diagonal is exactly zero
+    # Floating-point arithmetic can leave tiny residuals (~1e-16) on diagonal
+    # scikit-bio requires exact zeros for distance matrix validation
+    np.fill_diagonal(jac_distance, 0)
+
     return jac_distance
 
 def F1(score, label):
@@ -260,15 +270,20 @@ def Splitmat(matsize,ncore):
 
 ##import csr
 def ReshapeJac(mat_conc,label_conc,jac_raw,core):
-    A = mat_conc[label_conc != 1]  
+    A = mat_conc[label_conc != 1]
     B = mat_conc[label_conc == 1]
 #     jac_extra = metrics.pairwise_distances(B.A, Y=mat_conc.A, metric='jaccard', n_jobs=core)
     jac_extra = CalJac(B,mat_conc)
     jac_new = np.vstack((jac_raw, jac_extra[:,0:A.shape[0]]))
     jac_new = np.hstack((jac_new,jac_extra.T))
 
+    # Fix for scikit-bio 0.7.0: ensure diagonal remains exactly zero after matrix combination
+    # Matrix stacking/concatenation can introduce values on the diagonal
+    # This ensures the combined distance matrix passes scikit-bio validation
+    np.fill_diagonal(jac_new, 0)
+
 #     for i in range(len(jac_new)):
-#         assert jac_new[i][i] == 0 
+#         assert jac_new[i][i] == 0
     return jac_new
 
 def PCoA(mat_jaccard,npc,showfig=False):


### PR DESCRIPTION
Hi Scotty,

Thank you for your previous feedback on maintaining sparse matrices during iteration. I've implemented a proper fix that addresses the SciPy 1.13+ compatibility issue while preserving the sparse matrix design as you suggested.

## Background

I previously reported the `NotImplementedError` when using scIBD with modern SciPy versions. In my initial workaround, I converted matrices to dense format early, which you correctly pointed out was inefficient. I've now implemented a better solution that keeps sparse matrices throughout the expensive operations.

## The Issue

When running scIBD with modern Python environments (SciPy ≥1.13, scikit-bio 0.7.0), I encountered two errors:

1. **SciPy 1.13+ breaking change**: 
   ```
   NotImplementedError: subtracting a sparse array from a nonzero scalar is not supported
   ```
   This occurs in the `CalJac` function at line 92: `jac_distance = (1-intersect/union).A`

2. **scikit-bio 0.7.0 strict validation**:
   ```
   DistanceMatrixError: Data must be hollow (diagonal must contain only zeros)
   ```
   This happens because floating-point arithmetic leaves tiny residuals (~1e-16) on the diagonal instead of exact zeros.

## The Solution

I've made minimal changes to fix both issues while maintaining sparse matrix efficiency:

### Fix 1: CalJac - Reorder operations for SciPy 1.13+
**Before**:
```python
jac_distance = (1-intersect/union).A  # Tries: 1 - sparse_matrix (fails)
```

**After**:
```python
jac_distance = 1 - (intersect/union).toarray()  # Convert first, then subtract (works)
```

### Fix 2: Diagonal zeroing for scikit-bio validation
```python
np.fill_diagonal(jac_distance, 0)
```

This ensures exact zeros on the diagonal. I noticed you had a commented assertion for this at lines 285-286, so this aligns with the original intent.

### Fix 3: ReshapeJac - Maintain zero diagonal after matrix combination
Added diagonal zeroing after `vstack`/`hstack` operations, since matrix concatenation can place values on the diagonal of the combined matrix.

## Testing

Successfully tested on my scATAC-seq sample. Both PCA and PCoA strategies work correctly, all iterations completed with proper doublet predictions.

## Environment Tested

- Python: 3.10.12
- NumPy: 2.0.2
- SciPy: 1.15.3 (issue affects ≥1.13)
- scikit-bio: 0.7.0
- scIBD: 0.1.3

This fix maintains backward compatibility while ensuring scIBD works with current and future package versions.

Thank you again for your excellent tool and for the guidance!

Best regards,
Anton